### PR TITLE
Add Atmel Studio as a installation target

### DIFF
--- a/src/SaveAllTheTabs/source.extension.vsixmanifest
+++ b/src/SaveAllTheTabs/source.extension.vsixmanifest
@@ -12,6 +12,7 @@
   </Metadata>
   <Installation InstalledByMsi="false">
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[12.0,16.0)" />
+    <InstallationTarget Id="AtmelStudio" Version="[7.0,8.0)" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Atmel Studio 7 is based on VS2015, so this extension works as expected in it.